### PR TITLE
Changed return type to string from JObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 A C# port of the [samwise Ruby gem](https://github.com/18F/samwise) for the SAM.gov API.
 
-
 ## Run tests
 
-```bash
+```shell
 ~$ dotnet test SamDotNet.Tests/SamDotNet.Tests.csproj
 ```
 
@@ -57,14 +56,14 @@ namespace SamDotNet.Demo
 
             Sam sam = new Sam(key);
             var result = sam.GetDunsInfo(duns_number);
-            Console.WriteLine(JsonConvert.SerializeObject(result));
+            Console.WriteLine(JsonConvert.DeserializeObject(result));
         }
     }
 }
 ```
 
 * Invoke thusly: ```~$ dotnet run "DEMO_KEY" "1459697830000" ```
-
+* Note - the result returned by the library is a JSON string. The consumer is responsible for de-serializing the string into a C# object. The example above uses [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/), but you could also use [System.Text.Json](https://docs.microsoft.com/en-us/dotnet/api/system.text.json?view=netcore-3.1) (or another package) as well.
 * Result:
 
 ```json

--- a/SamDotNet.Demo/DunsLookup.cs
+++ b/SamDotNet.Demo/DunsLookup.cs
@@ -13,7 +13,7 @@ namespace SamDotNet.Demo
             // Instantiate a new object and retrieve DUNS info.
             Sam sam = new Sam(key);
             var result = sam.GetDunsInfo(duns_number);
-            Console.WriteLine(JsonConvert.SerializeObject(result));
+            Console.WriteLine(JsonConvert.DeserializeObject(result));
         }
     }
 }

--- a/SamDotNet.Tests/SamDotNetTests.cs
+++ b/SamDotNet.Tests/SamDotNetTests.cs
@@ -27,7 +27,7 @@ namespace SamDotNet.Tests
         {
             // Assemble
             Sam testSam = new Sam(_key, testClient);
-            var expected = typeof(JObject);
+            var expected = typeof(string);
 
             // Act
             var actual = testSam.GetDunsInfo("9990009999");
@@ -41,7 +41,7 @@ namespace SamDotNet.Tests
         {
             // Assemble
             Sam testSam = new Sam(_key, testClient);
-            var expected = typeof(JObject);
+            var expected = typeof(string);
 
             // Act
             var actual = testSam.GetSamStatus("9990009999");
@@ -55,7 +55,7 @@ namespace SamDotNet.Tests
         {
             // Assemble
             Sam testSam = new Sam(_key, testClient);
-            var expected = typeof(JObject);
+            var expected = typeof(string);
 
             // Act
             var actual = testSam.CheckDunsInSam("9990009999");
@@ -69,7 +69,7 @@ namespace SamDotNet.Tests
         {
             // Assemble
             Sam testSam = new Sam(_key, testClient);
-            var expected = typeof(JObject);
+            var expected = typeof(string);
 
             // Act
             var actual = testSam.CheckForExclusions("9990009999");


### PR DESCRIPTION
Previously, the library return a `JObject` from method calls, requiring consumers to use [Newtonsoft.JSON](https://www.nuget.org/packages/Newtonsoft.Json/). .NET Core 3.0 introduces a new native JSON serializer / de-serializer that might be preferable to some users. As a result, the return type has been changed to a string from a `JObject`. Note, this is a breaking change as the consumer will not need to deserialize the result before using it (unless they want to use the raw JSON string).

